### PR TITLE
Member

### DIFF
--- a/src/main/java/com/programmers/emotiondiary/api/MemberApiController.java
+++ b/src/main/java/com/programmers/emotiondiary/api/MemberApiController.java
@@ -40,8 +40,8 @@ public class MemberApiController {
         return MembersInfoDto.convertMemberToDto(memberList);
     }
 
-    @DeleteMapping("/{memberId}")
-    public String deleteMember(@PathVariable Long memberId,
+    @DeleteMapping
+    public String deleteMember(@CookieValue("memberId") Long memberId,
                                @RequestBody @Valid ResignRequestDto resignRequestDto
     ) {
         memberService.deleteMember(memberId, resignRequestDto);

--- a/src/main/java/com/programmers/emotiondiary/service/MemberService.java
+++ b/src/main/java/com/programmers/emotiondiary/service/MemberService.java
@@ -18,6 +18,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional
     public Long signUp(SignupRequestDto signupRequestDto) {
         validateLoginId(signupRequestDto);
         Member member = Member.createMember(signupRequestDto);

--- a/src/test/java/com/programmers/emotiondiary/api/MemberApiControllerTest.java
+++ b/src/test/java/com/programmers/emotiondiary/api/MemberApiControllerTest.java
@@ -5,6 +5,7 @@ import com.programmers.emotiondiary.dtos.request.member.ResignRequestDto;
 import com.programmers.emotiondiary.dtos.request.member.SignupRequestDto;
 import com.programmers.emotiondiary.repository.MemberRepository;
 import com.programmers.emotiondiary.service.MemberService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,9 +125,10 @@ class MemberApiControllerTest {
 
         // when
         this.mockMvc.perform(
-                delete("/api/members/{memberId}", saveId)
+                delete("/api/members")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(resignRequestDto))
+                        .cookie(new Cookie("memberId", String.valueOf(saveId)))
         ).andExpect(status().isOk());
 
         // then
@@ -145,9 +147,10 @@ class MemberApiControllerTest {
 
         // when && then
         this.mockMvc.perform(
-                delete("/api/members/{memberId}", saveId + 1)
+                delete("/api/members")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(resignRequestDto))
+                        .cookie(new Cookie("memberId", String.valueOf(saveId + 1)))
         ).andExpect(status().isBadRequest());
 
     }
@@ -164,9 +167,10 @@ class MemberApiControllerTest {
 
         // when && then
         this.mockMvc.perform(
-                delete("/api/members/{memberId}", saveId)
+                delete("/api/members")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(resignRequestDto))
+                        .cookie(new Cookie("memberId", String.valueOf(saveId)))
         ).andExpect(status().isBadRequest());
 
     }
@@ -183,9 +187,10 @@ class MemberApiControllerTest {
 
         // when && then
         this.mockMvc.perform(
-                delete("/api/members/{memberId}", saveId)
+                delete("/api/members")
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(resignRequestDto))
+                        .cookie(new Cookie("memberId", String.valueOf(saveId)))
         ).andExpect(status().isBadRequest());
 
     }


### PR DESCRIPTION
# 구현 사항 
 
- 회원 탈퇴 시 Controller 변경 
  - 기존 : @PathVariable 사용 
  - 변경 후 : @Cookie를 사용 
- Service 클래스 @Transactional 잘못된 사용 변경 
  - 기존 : 회원 가입 시 @Transactional(read-only:true) 적용됨 
    - open-session-in-view : on 설정으로 인해 장애는 나지 않음
  - 변경 후 : 회원 가입 관련한 메서드에 @Transactional(read-only:false) 적용